### PR TITLE
Introduce ``below`` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ For example, show path orientation on mouse over :
 * `repeat` Specifies if the text should be repeated along the polyline (Default: `false`)
 * `center` Centers the text according to the polyline's bounding box  (Default: `false`)
 * `attributes` Object containing the attributes applied to the `text` tag. Check valid attributes [here](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/text#Attributes) (Default: `{}`)
+* `below` Show text below the path (Default: false)
 
 Screenshot
 ----------
@@ -44,7 +45,10 @@ Changelog
 
 ### master ###
 
-* Nothing changed yet.
+**Breaking changes**
+
+* Set option ``below`` to true to put the text below the layer. It is shown
+  on top by default.
 
 ### 0.2.2 ###
 

--- a/leaflet.textpath.js
+++ b/leaflet.textpath.js
@@ -53,7 +53,12 @@ var PolylineTextPath = {
           return this;
         }
 
-        var defaults = {repeat: false, fillColor: 'black', attributes: {}};
+        var defaults = {
+            repeat: false,
+            fillColor: 'black',
+            attributes: {},
+            below: false,
+        };
         options = L.Util.extend(defaults, options);
 
         /* If empty text, hide */
@@ -98,9 +103,15 @@ var PolylineTextPath = {
             textNode.setAttribute(attr, options.attributes[attr]);
         textPath.appendChild(document.createTextNode(text));
         textNode.appendChild(textPath);
-        svg.insertBefore(textNode, svg.firstChild);
         this._textNode = textNode;
-        
+
+        if (options.below) {
+            svg.insertBefore(textNode, svg.firstChild);
+        }
+        else {
+            svg.appendChild(textNode);
+        }
+
         /* Center text according to the path's bounding box */
         if (options.center) {
             var textWidth = textNode.getBBox().width;


### PR DESCRIPTION
We have two conflicting expectations regarding z-index of text.

See:
- https://github.com/makinacorpus/Leaflet.TextPath/issues/20
- https://github.com/makinacorpus/Leaflet.TextPath/issues/5

And respective jsfiddle:
- http://jsfiddle.net/sir_kitty/cmhbQ/2/
- http://jsfiddle.net/5d3owLdw/3/

@Abbe98 @fuatsengul @akshayme @p-j @solo999 do you guyz have a better idea that adding an option like this ?

Thanks for your feedback !
