### PR TITLE
Change getBBox to getBoundingClientRect

### DIFF
--- a/leaflet.textpath.js
+++ b/leaflet.textpath.js
@@ -114,7 +114,7 @@ var PolylineTextPath = {
 
         /* Center text according to the path's bounding box */
         if (options.center) {
-            var textWidth = textNode.getBBox().width;
+            var textWidth = textNode.getBoundingClientRect().width;
             var pathWidth = this._path.getBoundingClientRect().width;
             /* Set the position for the left side of the textNode */
             textNode.setAttribute('dx', ((pathWidth / 2) - (textWidth / 2)));


### PR DESCRIPTION
Firefox doesn't support using getBBox for elements that aren't visible, switch to using getBoundingClientRect which will return 0 for dimensions of invisible elements.

This may resolve #54 and certainly resolves the issue I'm having, which is that the map needs to be visible at all times for the textpath code to work.