### PR TITLE
Use absolute path for xlink:href attribute

### DIFF
--- a/leaflet.textpath.js
+++ b/leaflet.textpath.js
@@ -98,7 +98,7 @@ var PolylineTextPath = {
 
         var dy = options.offset || this._path.getAttribute('stroke-width');
 
-        textPath.setAttributeNS("http://www.w3.org/1999/xlink", "xlink:href", '#'+id);
+        textPath.setAttributeNS("http://www.w3.org/1999/xlink", "xlink:href", window.location.href + '#' + id);
         textNode.setAttribute('dy', dy);
         for (var attr in options.attributes)
             textNode.setAttribute(attr, options.attributes[attr]);


### PR DESCRIPTION
If a HTML page has a `<base>` tag, the text path isn't rendered correctly because it doesn't reference the polyline path's id correctly. This is a problem for example in Angular, which uses the `<base>` tag.