### PR TITLE
Fix Uncaught RangeError in some cases

### DIFF
--- a/leaflet.textpath.js
+++ b/leaflet.textpath.js
@@ -89,7 +89,9 @@ var PolylineTextPath = {
             svg.removeChild(pattern);
 
             /* Create string as long as path */
-            text = new Array(Math.ceil(this._path.getTotalLength() / alength)).join(text);
+            if (alength > 0) {
+                text = new Array(Math.ceil(this._path.getTotalLength() / alength)).join(text);
+            }
         }
 
         /* Put it along the path using textPath */


### PR DESCRIPTION
Prevent `RangeError Uncaught RangeError: Invalid array length`.