### PR TITLE
Fix crashing on map.remove()

### DIFF
--- a/leaflet.textpath.js
+++ b/leaflet.textpath.js
@@ -20,7 +20,7 @@ var PolylineTextPath = {
 
     onRemove: function (map) {
         map = map || this._map;
-        if (map && this._textNode)
+        if (map && this._textNode && map._renderer._container)
             map._renderer._container.removeChild(this._textNode);
         __onRemove.call(this, map);
     },


### PR DESCRIPTION
Calling map.remove() causes an exception, because we are trying to remove the text node from the map container which doesn't exists anymore. This PR checks for the container before removing the text node.