### PR TITLE
 Zero division fix (on leaflet.0.8-dev branch)

### DIFF
--- a/leaflet.textpath.js
+++ b/leaflet.textpath.js
@@ -77,7 +77,7 @@ var PolylineTextPath = {
         var svg = this._map._renderer._container;
         this._path.setAttribute('id', id);
 
-        if (options.repeat) {
+        if (options.repeat && document.body.contains(this._map._renderer._container)) {
             /* Compute single pattern length */
             var pattern = L.SVG.create('text');
             for (var attr in options.attributes)
@@ -88,7 +88,7 @@ var PolylineTextPath = {
             svg.removeChild(pattern);
 
             /* Create string as long as path */
-            text = new Array(Math.ceil(this._path.getTotalLength() / (alength || 1))).join(text);
+            text = new Array(Math.ceil(this._path.getTotalLength() / alength)).join(text);
         }
 
         /* Put it along the path using textPath */

--- a/leaflet.textpath.js
+++ b/leaflet.textpath.js
@@ -88,7 +88,7 @@ var PolylineTextPath = {
             svg.removeChild(pattern);
 
             /* Create string as long as path */
-            text = new Array(Math.ceil(this._path.getTotalLength() / alength)).join(text);
+            text = new Array(Math.ceil(this._path.getTotalLength() / (alength || 1))).join(text);
         }
 
         /* Put it along the path using textPath */

--- a/leaflet.textpath.js
+++ b/leaflet.textpath.js
@@ -77,7 +77,7 @@ var PolylineTextPath = {
         var svg = this._map._renderer._container;
         this._path.setAttribute('id', id);
 
-        if (options.repeat && document.body.contains(this._map._renderer._container)) {
+        if (options.repeat) {
             /* Compute single pattern length */
             var pattern = L.SVG.create('text');
             for (var attr in options.attributes)
@@ -88,7 +88,7 @@ var PolylineTextPath = {
             svg.removeChild(pattern);
 
             /* Create string as long as path */
-            text = new Array(Math.ceil(this._path.getTotalLength() / alength)).join(text);
+            text = new Array(Math.ceil(this._path.getTotalLength() / (alength || 1))).join(text);
         }
 
         /* Put it along the path using textPath */


### PR DESCRIPTION
If the map was mounted to a node that's not in the DOM (which is not so rare for example in React environment), an error was thrown because `pattern.getComputedTextLength()` resulted in 0, which caused a division by zero. I fixed the bug by checking if the map is rendered in the body.

You can reproduce the bug like this:
```
document.createElement("div").appendChild(mapContainerNode);
map.invalidateSize();
```

