### PR TITLE
Update mainline by porting changes from leaflet0.8-dev branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+
+1.2.0 / 2018-03-01
+==================
+
+  * Add npm script to help releasing package versions
+  * Set Leaflet as peerDependency
+  * Upgrade Leaflet version from demo to `1.3.1`
+  * Don't try to remove from container if container doesn't exist
+  * Change way of dealing with the SVG to comply with leaflet >= 0.8
+  * Remove useless console.log

--- a/README.md
+++ b/README.md
@@ -8,9 +8,7 @@ Check out the [demo](http://makinacorpus.github.com/Leaflet.TextPath/) !
 Leaflet versions
 -----
 
-The version on the `gh-pages` branch targets Leaflet 0.7.3.
-
-Please use the `leaflet0.8-dev` branch to be compatible with the development version of Leaflet (0.8).
+The version on the `gh-pages` branch targets Leaflet `1.3.1`.
 
 Usage
 -----

--- a/index.html
+++ b/index.html
@@ -3,9 +3,9 @@
 <head>
     <title>Leaflet.TextPath</title>
 
-    <link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet-0.7/leaflet.css" />
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.3.1/dist/leaflet.css" />
 
-    <script src="http://cdn.leafletjs.com/leaflet-0.7/leaflet.js"></script>
+    <script src="https://unpkg.com/leaflet@1.3.1/dist/leaflet.js"></script>
     <script src="leaflet.textpath.js"></script>
     <style>
         #map {

--- a/leaflet.textpath.js
+++ b/leaflet.textpath.js
@@ -21,7 +21,7 @@ var PolylineTextPath = {
 
     onRemove: function (map) {
         map = map || this._map;
-        if (map && this._textNode)
+        if (map && this._textNode && map._renderer._container)
             map._renderer._container.removeChild(this._textNode);
         __onRemove.call(this, map);
     },

--- a/leaflet.textpath.js
+++ b/leaflet.textpath.js
@@ -22,7 +22,7 @@ var PolylineTextPath = {
     onRemove: function (map) {
         map = map || this._map;
         if (map && this._textNode)
-            map._pathRoot.removeChild(this._textNode);
+            map._renderer._container.removeChild(this._textNode);
         __onRemove.call(this, map);
     },
 
@@ -65,7 +65,7 @@ var PolylineTextPath = {
         /* If empty text, hide */
         if (!text) {
             if (this._textNode && this._textNode.parentNode) {
-                this._map._pathRoot.removeChild(this._textNode);
+                this._map._renderer._container.removeChild(this._textNode);
                 
                 /* delete the node, so it will not be removed a 2nd time if the layer is later removed from the map */
                 delete this._textNode;
@@ -75,12 +75,12 @@ var PolylineTextPath = {
 
         text = text.replace(/ /g, '\u00A0');  // Non breakable spaces
         var id = 'pathdef-' + L.Util.stamp(this);
-        var svg = this._map._pathRoot;
+        var svg = this._map._renderer._container;
         this._path.setAttribute('id', id);
 
         if (options.repeat) {
             /* Compute single pattern length */
-            var pattern = L.Path.prototype._createElement('text');
+            var pattern = L.SVG.create('text');
             for (var attr in options.attributes)
                 pattern.setAttribute(attr, options.attributes[attr]);
             pattern.appendChild(document.createTextNode(text));
@@ -93,8 +93,8 @@ var PolylineTextPath = {
         }
 
         /* Put it along the path using textPath */
-        var textNode = L.Path.prototype._createElement('text'),
-            textPath = L.Path.prototype._createElement('textPath');
+        var textNode = L.SVG.create('text'),
+            textPath = L.SVG.create('textPath');
 
         var dy = options.offset || this._path.getAttribute('stroke-width');
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
         "url": "git://github.com/makinacorpus/Leaflet.TextPath.git"
     },
     "license": "MIT",
-    "scripts": {},
+    "scripts": {
+        "version": "git changelog -t $npm_package_version && git add CHANGELOG.md"
+    },
     "peerDependencies": {
         "leaflet": "^1.3.1"
     }

--- a/package.json
+++ b/package.json
@@ -1,8 +1,12 @@
 {
     "name": "leaflet-textpath",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "description": "Shows a text (or a pattern) along a Polyline",
-    "keywords": ["Leaflet", "GIS", "SVG"],
+    "keywords": [
+        "Leaflet",
+        "GIS",
+        "SVG"
+    ],
     "main": "leaflet.textpath.js",
     "bugs": {
         "url": "https://github.com/makinacorpus/Leaflet.TextPath/issues"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     },
     "license": "MIT",
     "scripts": {},
-    "dependencies": {
-        "leaflet": "*"
+    "peerDependencies": {
+        "leaflet": "^1.3.1"
     }
 }


### PR DESCRIPTION
Some improvements had been done in leaflet0.8-dev branch, but never ported on default branch of the repository.

This PR reapply thoses changes and propose bumping the plugin version to `1.2.0`.