### PR TITLE
repeat: specify distance in pixels

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ With a GeoJSON containing lines, it becomes:
 
 ### Options
 
-* `repeat` Specifies if the text should be repeated along the polyline (Default: `false`)
+* `repeat` Specifies if the text should be repeated along the polyline (Default: `false`). Specify `repeat` as float to set the distance between each repetition in pixels (will be approximated by spaces).
 * `center` Centers the text according to the polyline's bounding box  (Default: `false`)
 * `below` Show text below the path (Default: false)
 * `offset` Set an offset to position text relative to the polyline (Default: 0)

--- a/index.html
+++ b/index.html
@@ -188,7 +188,7 @@
 
         L.geoJson(flightsWE, {
             onEachFeature: function (feature, layer) {
-                layer.setText(feature.properties.flight, {offset: -5});
+                layer.setText(feature.properties.flight, {offset: -5, repeat: 20, center: true});
             },
             style: {
                 weight: 3,

--- a/leaflet.textpath.js
+++ b/leaflet.textpath.js
@@ -78,7 +78,7 @@ var PolylineTextPath = {
         var svg = this._map._renderer._container;
         this._path.setAttribute('id', id);
 
-        if (options.repeat) {
+        if (options.repeat !== false) {
             /* Compute single pattern length */
             var pattern = L.SVG.create('text');
             for (var attr in options.attributes)
@@ -88,8 +88,25 @@ var PolylineTextPath = {
             var alength = pattern.getComputedTextLength();
             svg.removeChild(pattern);
 
+            /* Compute length of a space */
+            var pattern = L.SVG.create('text');
+            for (var attr in options.attributes)
+                pattern.setAttribute(attr, options.attributes[attr]);
+            pattern.appendChild(document.createTextNode('\u00A0'));
+            svg.appendChild(pattern);
+            var slength = pattern.getComputedTextLength();
+            svg.removeChild(pattern);
+
             /* Create string as long as path */
-            text = new Array(Math.ceil(this._path.getTotalLength() / alength)).join(text);
+            var repeatDistance = parseFloat(options.repeat) || 0
+            var spacingBalance = 0
+            var singleText = text
+            for (var i = 1; i < Math.floor((this._path.getTotalLength() + repeatDistance) / (alength + repeatDistance)); i++) {
+                var spacesCount = Math.round((repeatDistance + spacingBalance) / slength)
+                spacingBalance = repeatDistance - (spacesCount * slength)
+
+                text += '\u00A0'.repeat(spacesCount) + singleText
+            }
         }
 
         /* Put it along the path using textPath */

--- a/leaflet.textpath.js
+++ b/leaflet.textpath.js
@@ -44,6 +44,20 @@ var PolylineTextPath = {
         }
     },
 
+    _getLength: function (text, options) {
+        var svg = this._map._renderer._container;
+
+        var pattern = L.SVG.create('text');
+        for (var attr in options.attributes)
+            pattern.setAttribute(attr, options.attributes[attr]);
+        pattern.appendChild(document.createTextNode(text));
+        svg.appendChild(pattern);
+        var length = pattern.getComputedTextLength();
+        svg.removeChild(pattern);
+
+        return length;
+    },
+
     setText: function (text, options) {
         this._text = text;
         this._textOptions = options;
@@ -80,22 +94,10 @@ var PolylineTextPath = {
 
         if (options.repeat !== false) {
             /* Compute single pattern length */
-            var pattern = L.SVG.create('text');
-            for (var attr in options.attributes)
-                pattern.setAttribute(attr, options.attributes[attr]);
-            pattern.appendChild(document.createTextNode(text));
-            svg.appendChild(pattern);
-            var alength = pattern.getComputedTextLength();
-            svg.removeChild(pattern);
+            var alength = this._getLength(text, options);
 
             /* Compute length of a space */
-            var pattern = L.SVG.create('text');
-            for (var attr in options.attributes)
-                pattern.setAttribute(attr, options.attributes[attr]);
-            pattern.appendChild(document.createTextNode('\u00A0'));
-            svg.appendChild(pattern);
-            var slength = pattern.getComputedTextLength();
-            svg.removeChild(pattern);
+            var slength = this._getLength('\u00A0', options);
 
             /* Create string as long as path */
             var repeatDistance = parseFloat(options.repeat) || 0


### PR DESCRIPTION
With this change you can pass the `repeat` parameter as float, which specifies the distance between repeated labels in pixels. As gap a group of spaces will be used, which approximates the specified distance.

Example (with repeat: 20, center: true):
![repeat-distance](https://user-images.githubusercontent.com/249012/50361290-55268600-0563-11e9-8855-aef35ef7db85.png)