### PR TITLE
Bug fix for potential zero dived by zero

### DIFF
--- a/leaflet.textpath.js
+++ b/leaflet.textpath.js
@@ -89,7 +89,7 @@ var PolylineTextPath = {
             svg.removeChild(pattern);
 
             /* Create string as long as path */
-            text = new Array(Math.ceil(this._path.getTotalLength() / alength)).join(text);
+            text = new Array(Math.ceil(isNaN(this._path.getTotalLength() / alength) ? 0 : this._path.getTotalLength() / alength)).join(text);
         }
 
         /* Put it along the path using textPath */


### PR DESCRIPTION
There is a bug with `this._path.getTotalLength() / alength` on line 92. I have a project where `this._path.getTotalLength()` is computed as 0 and `alength` also is computed as 0. Dividing 0 by 0 isn't possible in math. When this happens, it breaks the script from going any further. 

My proposed change resolves this problem. If `this._path.getTotalLength() / alength` is evaluated as NaN, it sets `test` to 0, otherwise `test` becomes the computed division.